### PR TITLE
Migrate from scalar %x to keys %x to be consistent between perl versi…

### DIFF
--- a/t/27-cmd_e.t
+++ b/t/27-cmd_e.t
@@ -56,7 +56,7 @@ is
 	,$files->{ 'last eval' }
 	,'Eval last expression if none supplied';
 
-$cmd =  's;$x;e $x;$x++;e $x;s;e $x;s;e $x;s;@x;scalar @x;e \@x;s;%x;scalar %x;e \%x;';
+$cmd =  's;$x;e $x;$x++;e $x;s;e $x;s;e $x;s;@x;scalar @x;e \@x;s;%x;0+keys(%x);e \%x;';
 is
 	n( `$^X $lib -d:DbInteract='$cmd' -e '$script'` )
 	,$files->{ 'eval' }
@@ -137,7 +137,7 @@ a 1
 ["a", 1]
 -e:0006  2;
 a 1
-1/8
+1
 { a => 1 }
 @@ @_ not clash
 -e:0004  t( 1, [], {} );


### PR DESCRIPTION
…ons <> perl-5.26.0

I was trying to build your module in perl-5.26.0 on my mac, and had a single line difference during the tests.  I traced it down to the fact that scalar %hash changed with perl 5.26.0.  I made a small change to swap from using scalar %x to just calling keys in scalar context to get a more consistent value that still tests the code.

http://search.cpan.org/dist/perl-5.26.0/pod/perldelta.pod#scalar(%hash)_return_signature_changed

Thanks, 

Brian